### PR TITLE
Use FQDN instead of Hostname

### DIFF
--- a/boundary_plugin.py
+++ b/boundary_plugin.py
@@ -11,7 +11,7 @@ import os
 
 __version__ = '1.1.0'
 
-HOSTNAME = socket.gethostname()
+HOSTNAME = socket.getfqdn()
 
 metric_log_file = None
 plugin_params = None


### PR DESCRIPTION
As of now, boundary meter sends data with source equal to the machine's FQDN, while Riak plugin does not.
Using FQDN instead of hostname allows to see other metrics along with Riak one in the same dashboard without manual selection of hosts.

Optionally, a deeper modification may allow the override of HOSTNAME default value via plugin configuration. Let me know which one you prefer.